### PR TITLE
Change jacoco skip to false for sonar cloud run

### DIFF
--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -35,4 +35,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: 
           cd Final\ Systems/Extensible\ Clustering/Extensible\ Clustering/ &&
-          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=dave-t-c_Extensible-Clustering
+          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=dave-t-c_Extensible-Clustering -Djacoco.skip=false


### PR DESCRIPTION
This should force the coverage check to run.

This PR is being used to try and identify a fix for #5 